### PR TITLE
fix: ログイン後のリダイレクト先を booklog/input に修正

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -90,7 +90,7 @@ const addBooksToBooklog = async (AsinList) => {
   // セッション切れまたは初回: ログインページにリダイレクトされた場合
   if (!page.url().startsWith('https://booklog.jp/input')) {
     console.log('ブラウザでブクログにログインしてください（reCAPTCHA を解いてログインボタンを押してください）');
-    await page.waitForURL('https://booklog.jp/home', { timeout: 300000 });
+    await page.waitForURL('https://booklog.jp/input', { timeout: 300000 });
     // セッションを保存
     await context.storageState({ path: SESSION_FILE });
     await page.goto('https://booklog.jp/input');


### PR DESCRIPTION
## Summary

-  `booklog/input` にアクセスしようとして、ブクログのセッション切れでログインページにリダイレクトされた後、ログイン成功時のリダイレクト先が `booklog/home` ではなく `booklog/input` であることを確認
- `waitForURL` の待機先 URL を `booklog/home` から `booklog/input` に修正

## Test plan

- [x] セッションファイルを削除してツールを実行し、ログインページへのリダイレクトが発生することを確認
- [x] ログイン後に `booklog/input` へ正しくリダイレクトされ、処理が継続されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)