### PR TITLE
Add minimal workflow permissions to test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `permissions:` to the test workflow
- Grant `contents: read` so the checkout step can access repository contents with least privilege

## Testing
- Not run (not requested)