### PR TITLE
Add Codex guidance for Python formatting and tests

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,132 @@
+name: ruff
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  checks: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Sync dependencies
+        run: uv sync --group dev
+
+      - name: Run ruff with fixes
+        run: |
+          uv run --group dev ruff check . --fix
+          uv run --group dev ruff format .
+
+      - name: Capture ruff diff
+        id: diff
+        shell: bash
+        run: |
+          if git diff --quiet --exit-code; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          git diff -- . > ruff.patch
+
+      - name: Update PR with ruff suggestion
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          HAS_CHANGES: ${{ steps.diff.outputs.has_changes }}
+        with:
+          script: |
+            const fs = require("fs");
+
+            const marker = "<!-- codex-ruff-suggestion -->";
+            const issue_number = context.issue.number;
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.data.find(
+              (comment) =>
+                comment.user?.type === "Bot" && comment.body?.includes(marker),
+            );
+
+            if (process.env.HAS_CHANGES !== "true") {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            let diff = fs.readFileSync("ruff.patch", "utf8");
+            const maxLength = 60_000;
+            const truncated = diff.length > maxLength;
+            if (truncated) {
+              diff = `${diff.slice(0, maxLength)}\n... diff truncated ...\n`;
+            }
+
+            const body = [
+              marker,
+              "Ruff found auto-fixable changes for this pull request.",
+              "",
+              "Run these commands locally and push the result:",
+              "",
+              "```bash",
+              "uv run --group dev ruff check . --fix",
+              "uv run --group dev ruff format .",
+              "```",
+              "",
+              "Suggested diff:",
+              "",
+              "```diff",
+              diff,
+              "```",
+              truncated
+                ? "The diff was truncated to fit within GitHub comment limits."
+                : "",
+            ].join("\n");
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body,
+            });
+
+      - name: Fail if ruff changed files
+        if: steps.diff.outputs.has_changes == 'true'
+        run: |
+          echo "Ruff produced changes. Apply the suggested diff from the workflow comment."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Codex Instructions
+
+## Python Changes
+
+When modifying Python code in this repository, always finish by running the following commands and make sure they succeed:
+
+```bash
+rtk uv run --group dev ruff check . --fix
+rtk uv run --group dev ruff format .
+rtk uv run --group dev coverage run -m unittest discover -s tests
+```
+
+If a command cannot be completed in the current sandbox because of permissions or cache access, rerun it with the required approval instead of skipping it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@
 When modifying Python code in this repository, always finish by running the following commands and make sure they succeed:
 
 ```bash
-rtk uv run --group dev ruff check . --fix
-rtk uv run --group dev ruff format .
-rtk uv run --group dev coverage run -m unittest discover -s tests
+uv run --group dev ruff check . --fix
+uv run --group dev ruff format .
+uv run --group dev coverage run -m unittest discover -s tests
 ```
 
 If a command cannot be completed in the current sandbox because of permissions or cache access, rerun it with the required approval instead of skipping it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ kindle-to-booklog = "kindle_to_booklog.cli:main"
 [dependency-groups]
 dev = [
   "coverage[toml]>=7.10,<8",
+  "ruff>=0.11,<1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/kindle_to_booklog/booklog.py
+++ b/src/kindle_to_booklog/booklog.py
@@ -41,7 +41,9 @@ def add_books_to_booklog(
 
             # セッション切れまたは初回: ログインページにリダイレクトされた場合
             if not page.url.startswith(booklog_input_url):
-                print("ブラウザでブクログにログインしてください（reCAPTCHA を解いてログインボタンを押してください）")
+                print(
+                    "ブラウザでブクログにログインしてください（reCAPTCHA を解いてログインボタンを押してください）"
+                )
                 page.wait_for_url(booklog_input_url, timeout=300_000)
                 # セッションを保存
                 context.storage_state(path=str(session_file))

--- a/src/kindle_to_booklog/cli.py
+++ b/src/kindle_to_booklog/cli.py
@@ -3,7 +3,10 @@ import sys
 from playwright.sync_api import sync_playwright
 
 from kindle_to_booklog.booklog import add_books_to_booklog
-from kindle_to_booklog.kindle import get_asin_list_from_kindle_sqlite_db, get_asin_list_from_kindle_xml
+from kindle_to_booklog.kindle import (
+    get_asin_list_from_kindle_sqlite_db,
+    get_asin_list_from_kindle_xml,
+)
 
 
 def main() -> int:

--- a/src/kindle_to_booklog/kindle.py
+++ b/src/kindle_to_booklog/kindle.py
@@ -51,7 +51,10 @@ def get_asin_list_from_kindle_xml() -> list[str]:
     if not userprofile:
         raise RuntimeError("USERPROFILE is not set")
 
-    kindle_xml_path = Path(userprofile) / "AppData/Local/Amazon/Kindle/Cache/KindleSyncMetadataCache.xml"
+    kindle_xml_path = (
+        Path(userprofile)
+        / "AppData/Local/Amazon/Kindle/Cache/KindleSyncMetadataCache.xml"
+    )
     return load_asins_from_xml_path(kindle_xml_path)
 
 
@@ -81,5 +84,8 @@ def get_asin_list_from_kindle_sqlite_db() -> list[str]:
     if not home:
         raise RuntimeError("HOME is not set")
 
-    kindle_sqlite_path = Path(home) / "Library/Containers/com.amazon.Lassen/Data/Library/Protected/BookData.sqlite"
+    kindle_sqlite_path = (
+        Path(home)
+        / "Library/Containers/com.amazon.Lassen/Data/Library/Protected/BookData.sqlite"
+    )
     return load_asins_from_sqlite_path(kindle_sqlite_path)

--- a/tests/test_booklog.py
+++ b/tests/test_booklog.py
@@ -125,12 +125,16 @@ class BooklogTests(unittest.TestCase):
 
             add_books_to_booklog(
                 ["B000000001", "B000000002"],
-                playwright_factory=lambda: FakePlaywrightManager(FakePlaywright(chromium)),
+                playwright_factory=lambda: FakePlaywrightManager(
+                    FakePlaywright(chromium)
+                ),
                 session_file=session_file,
                 browser_channel="msedge",
             )
 
-            self.assertEqual(chromium.launch_calls, [{"headless": False, "channel": "msedge"}])
+            self.assertEqual(
+                chromium.launch_calls, [{"headless": False, "channel": "msedge"}]
+            )
             self.assertEqual(
                 browser.new_context_calls,
                 [
@@ -160,12 +164,23 @@ class BooklogTests(unittest.TestCase):
 
             add_books_to_booklog(
                 ["B000000009"],
-                playwright_factory=lambda: FakePlaywrightManager(FakePlaywright(chromium)),
+                playwright_factory=lambda: FakePlaywrightManager(
+                    FakePlaywright(chromium)
+                ),
                 session_file=session_file,
             )
 
-            self.assertEqual(page.goto_calls, ["https://booklog.jp/input", "https://booklog.jp/input"])
-            self.assertEqual(page.waited_urls, [("https://booklog.jp/input", 300_000), ("https://booklog.jp/input", None)])
+            self.assertEqual(
+                page.goto_calls,
+                ["https://booklog.jp/input", "https://booklog.jp/input"],
+            )
+            self.assertEqual(
+                page.waited_urls,
+                [
+                    ("https://booklog.jp/input", 300_000),
+                    ("https://booklog.jp/input", None),
+                ],
+            )
             self.assertEqual(context.storage_state_paths, [str(session_file)])
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,10 @@ class CliTests(unittest.TestCase):
         fake_factory = object()
         with (
             patch("kindle_to_booklog.cli.sys.platform", "win32"),
-            patch("kindle_to_booklog.cli.get_asin_list_from_kindle_xml", return_value=["B1", "B2"]) as get_xml,
+            patch(
+                "kindle_to_booklog.cli.get_asin_list_from_kindle_xml",
+                return_value=["B1", "B2"],
+            ) as get_xml,
             patch("kindle_to_booklog.cli.add_books_to_booklog") as add_books,
             patch("kindle_to_booklog.cli.sync_playwright", fake_factory),
             redirect_stdout(io.StringIO()) as stdout,

--- a/tests/test_kindle.py
+++ b/tests/test_kindle.py
@@ -5,7 +5,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from kindle_to_booklog.kindle import load_asins_from_sqlite_path, load_asins_from_xml_path, parse_purchase_date
+from kindle_to_booklog.kindle import (
+    load_asins_from_sqlite_path,
+    load_asins_from_xml_path,
+    parse_purchase_date,
+)
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 

--- a/uv.lock
+++ b/uv.lock
@@ -174,13 +174,17 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage", extra = ["toml"] },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [{ name = "playwright", specifier = ">=1.50,<2" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "coverage", extras = ["toml"], specifier = ">=7.10,<8" }]
+dev = [
+    { name = "coverage", extras = ["toml"], specifier = ">=7.10,<8" },
+    { name = "ruff", specifier = ">=0.11,<1" },
+]
 
 [[package]]
 name = "playwright"
@@ -211,6 +215,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add repository-level Codex instructions in `AGENTS.md` for Python changes.
- Document the expected local workflow after Python edits: `ruff check --fix`, `ruff format`, and the test suite.
- Apply `ruff`-driven formatting updates across the existing Python sources and tests.
- Add a GitHub Actions workflow for `ruff` that runs on pull requests and pushes to `main`.
- Pin workflow `uses:` entries by commit hash, including `actions/github-script` for PR automation.
- When `ruff check --fix` or `ruff format` would change files, post the suggested diff back to the pull request and fail the job until the changes are applied.

## Testing
- `uv run --group dev ruff check . --fix`
- `uv run --group dev ruff format .`
- `uv run --group dev coverage run -m unittest discover -s tests`