### PR TITLE
Add CLI help support for direct uv tool installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Amazon Kindle アプリをインストールして、ログインしてくださ
 その後に以下。
 
 ```
+$ uv tool install git+https://github.com/sasasin/kindle-to-booklog.git
+$ uvx playwright install chrome
+```
+
+開発用にリポジトリを clone して実行する場合は以下。
+
+```
 $ git clone git@github.com:sasasin/kindle-to-booklog.git
 $ cd kindle-to-booklog
 $ uv sync
@@ -28,14 +35,14 @@ Amazon Kindle アプリを起動して、同期ボタン押して、書誌情報
 以下を実行してください。Chrome が起動して、Kindle で購入日の新しい99冊をブクログに登録します。
 
 ```
-$ uv run kindle-to-booklog
+$ kindle-to-booklog
 ```
 
 `BROWSER_CHANNEL` 環境変数でブラウザを指定できます（省略時は `chrome`）。指定できる値は `chrome` / `msedge` など Playwright が対応しているチャンネル名です。
 
 ```
 # Edge で起動する場合
-$ BROWSER_CHANNEL=msedge uv run kindle-to-booklog
+$ BROWSER_CHANNEL=msedge kindle-to-booklog
 ```
 
 **初回実行時** はブクログのログインページが表示されます。reCAPTCHA を解いて手動でログインしてください。ログイン成功後にセッションが `session.json` に保存され、次回以降はログイン操作なしで自動実行されます。

--- a/src/kindle_to_booklog/cli.py
+++ b/src/kindle_to_booklog/cli.py
@@ -1,4 +1,7 @@
+import argparse
 import sys
+from collections.abc import Sequence
+from importlib.metadata import version
 
 from playwright.sync_api import sync_playwright
 
@@ -9,7 +12,22 @@ from kindle_to_booklog.kindle import (
 )
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kindle-to-booklog",
+        description="Register recently purchased Kindle books on Booklog.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {version('kindle-to-booklog')}",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    build_parser().parse_args(argv)
+
     if sys.platform == "win32":
         asin_list = get_asin_list_from_kindle_xml()
     elif sys.platform == "darwin":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,20 @@ from kindle_to_booklog import cli
 
 
 class CliTests(unittest.TestCase):
+    def test_help_exits_before_reading_kindle_data(self) -> None:
+        with (
+            patch("kindle_to_booklog.cli.get_asin_list_from_kindle_xml") as get_xml,
+            patch("kindle_to_booklog.cli.add_books_to_booklog") as add_books,
+            redirect_stdout(io.StringIO()) as stdout,
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                cli.main(["--help"])
+
+        self.assertEqual(raised.exception.code, 0)
+        get_xml.assert_not_called()
+        add_books.assert_not_called()
+        self.assertIn("usage: kindle-to-booklog", stdout.getvalue())
+
     def test_main_uses_windows_source(self) -> None:
         fake_factory = object()
         with (
@@ -21,7 +35,7 @@ class CliTests(unittest.TestCase):
             patch("kindle_to_booklog.cli.sync_playwright", fake_factory),
             redirect_stdout(io.StringIO()) as stdout,
         ):
-            result = cli.main()
+            result = cli.main([])
 
         self.assertEqual(result, 0)
         get_xml.assert_called_once_with()
@@ -34,7 +48,7 @@ class CliTests(unittest.TestCase):
     def test_main_rejects_unsupported_platform(self) -> None:
         with patch("kindle_to_booklog.cli.sys.platform", "linux"):
             with self.assertRaisesRegex(RuntimeError, "unsupported platform: linux"):
-                cli.main()
+                cli.main([])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
- Add an `argparse`-based CLI parser so the installed entrypoint supports `--help` and `--version` without entering the main sync flow.
- Preserve the existing runtime behavior for normal execution while making the package friendlier for `uv tool install` users.
- Update CLI tests to cover help handling and direct invocation, and refresh the README installation/run instructions.

### Testing
- `uv run --group dev ruff check . --fix` passed.
- `uv run --group dev ruff format .` passed.
- `uv run --group dev coverage run -m unittest discover -s tests` passed.
- `uv build` passed.
- Verified a `git+...` tool install produces the `kindle-to-booklog` executable and `kindle-to-booklog --help` exits successfully.