### PR TITLE
Support new Windows Kindle app metadata path

### DIFF
--- a/src/kindle_to_booklog/cli.py
+++ b/src/kindle_to_booklog/cli.py
@@ -8,7 +8,7 @@ from playwright.sync_api import sync_playwright
 from kindle_to_booklog.booklog import add_books_to_booklog
 from kindle_to_booklog.kindle import (
     get_asin_list_from_kindle_sqlite_db,
-    get_asin_list_from_kindle_xml,
+    get_asin_list_from_kindle_windows_app_xml,
 )
 
 
@@ -29,7 +29,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     build_parser().parse_args(argv)
 
     if sys.platform == "win32":
-        asin_list = get_asin_list_from_kindle_xml()
+        asin_list = get_asin_list_from_kindle_windows_app_xml()
     elif sys.platform == "darwin":
         asin_list = get_asin_list_from_kindle_sqlite_db()
     else:

--- a/src/kindle_to_booklog/kindle.py
+++ b/src/kindle_to_booklog/kindle.py
@@ -58,6 +58,19 @@ def get_asin_list_from_kindle_xml() -> list[str]:
     return load_asins_from_xml_path(kindle_xml_path)
 
 
+# for Windows Kindle app distributed from Microsoft Store
+def get_asin_list_from_kindle_windows_app_xml() -> list[str]:
+    localappdata = os.environ.get("LOCALAPPDATA")
+    if not localappdata:
+        raise RuntimeError("LOCALAPPDATA is not set")
+
+    kindle_xml_path = (
+        Path(localappdata)
+        / "Packages/AMZNKindle.AmazonKindleReadingApp_m1sc522ngdk36/LocalState/Classic/Data/Cache/KindleSyncMetadataCache.xml"
+    )
+    return load_asins_from_xml_path(kindle_xml_path)
+
+
 def load_asins_from_sqlite_path(kindle_sqlite_path: Path) -> list[str]:
     database = sqlite3.connect(kindle_sqlite_path)
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,9 @@ from kindle_to_booklog import cli
 class CliTests(unittest.TestCase):
     def test_help_exits_before_reading_kindle_data(self) -> None:
         with (
-            patch("kindle_to_booklog.cli.get_asin_list_from_kindle_xml") as get_xml,
+            patch(
+                "kindle_to_booklog.cli.get_asin_list_from_kindle_windows_app_xml"
+            ) as get_xml,
             patch("kindle_to_booklog.cli.add_books_to_booklog") as add_books,
             redirect_stdout(io.StringIO()) as stdout,
         ):
@@ -28,7 +30,7 @@ class CliTests(unittest.TestCase):
         with (
             patch("kindle_to_booklog.cli.sys.platform", "win32"),
             patch(
-                "kindle_to_booklog.cli.get_asin_list_from_kindle_xml",
+                "kindle_to_booklog.cli.get_asin_list_from_kindle_windows_app_xml",
                 return_value=["B1", "B2"],
             ) as get_xml,
             patch("kindle_to_booklog.cli.add_books_to_booklog") as add_books,

--- a/tests/test_kindle.py
+++ b/tests/test_kindle.py
@@ -6,6 +6,7 @@ import unittest
 from pathlib import Path
 
 from kindle_to_booklog.kindle import (
+    get_asin_list_from_kindle_windows_app_xml,
     load_asins_from_sqlite_path,
     load_asins_from_xml_path,
     parse_purchase_date,
@@ -19,10 +20,35 @@ class KindleTests(unittest.TestCase):
         parsed = parse_purchase_date("2024-01-02T03:04:05Z")
         self.assertEqual(parsed.isoformat(), "2024-01-02T03:04:05+00:00")
 
+    def test_parse_purchase_date_supports_windows_app_offset(self) -> None:
+        parsed = parse_purchase_date("2026-06-18T07:29:50+0000")
+        self.assertEqual(parsed.isoformat(), "2026-06-18T07:29:50+00:00")
+
     def test_load_asins_from_xml_path_filters_and_orders_books(self) -> None:
         xml_path = FIXTURES_DIR / "kindle_sync_metadata.xml"
 
         asin_list = load_asins_from_xml_path(xml_path)
+
+        self.assertEqual(
+            asin_list,
+            ["B000000001", "B000000002", "B000000003", "B000000005"],
+        )
+
+    def test_get_asin_list_from_kindle_windows_app_xml_uses_store_app_path(
+        self,
+    ) -> None:
+        xml_path = FIXTURES_DIR / "kindle_sync_metadata.xml"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            kindle_xml_path = (
+                Path(tmp_dir)
+                / "Packages/AMZNKindle.AmazonKindleReadingApp_m1sc522ngdk36/LocalState/Classic/Data/Cache/KindleSyncMetadataCache.xml"
+            )
+            kindle_xml_path.parent.mkdir(parents=True)
+            kindle_xml_path.write_text(xml_path.read_text(encoding="utf-8"))
+
+            with unittest.mock.patch.dict("os.environ", {"LOCALAPPDATA": tmp_dir}):
+                asin_list = get_asin_list_from_kindle_windows_app_xml()
 
         self.assertEqual(
             asin_list,


### PR DESCRIPTION
## Summary
- add a Windows Microsoft Store Kindle metadata reader using the new app package path
- switch Windows CLI reads to the new Kindle app XML while keeping the Legacy reader in place
- cover the Store app path and +0000 purchase-date format in tests

## Verification
- uv run --group dev ruff check . --fix
- uv run --group dev ruff format .
- uv run --group dev coverage run -m unittest discover -s tests